### PR TITLE
Chore: Update crate version and metadata for re-architecture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "pythonic-for"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Erkin Alp Güney <erkinalp9035@gmail.com>"]
-description = "A Rust crate that provides a Python-style for loop with an else clause"
+description = "A Rust crate that provides Python-style `for` and `while` loops with an optional `else` clause."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/erkinalp/pythonic-for"
 documentation = "https://docs.rs/pythonic-for"
 readme = "README.md"
-keywords = ["python", "for", "loop", "else", "iterator"]
-categories = ["rust-patterns", "no-std"]
+keywords = ["python", "for", "while", "loop", "do-while", "else", "control-flow", "iterator", "proc-macro"]
+categories = ["rust-patterns"]
 
 [dependencies]
-pythonic-for-proc-macros = { path = "./proc-macros", version = "0.1.0" }
+pythonic-for-proc-macros = { path = "./proc-macros", version = "0.2.0" }
 
 [workspace]
 members = ["proc-macros"]

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@
 [![Documentation](https://docs.rs/pythonic-for/badge.svg)](https://docs.rs/pythonic-for)
 [![License](https://img.shields.io/crates/l/pythonic-for.svg)](https://github.com/erkinalp/pythonic-for/blob/default/LICENSE-MIT)
 
-A Rust crate that provides a Python-style `for` loop with an optional `else` clause.
+A Rust crate that provides Python-style `for` and `while` loops with an optional `else` clause.
 
 ## Features
 
-- **Optional Else Clause**: The else clause is executed if the loop completes without a break or an error, similar to Python's for-else construct. The else clause is optional.
-- **Inclusive/Exclusive Ranges**: Supports both inclusive (`..=`) and exclusive (`..`) ranges.
-- **Step Values**: Allows specifying a step value for iteration, including negative steps for reverse iteration.
-- **Error Handling**: Handles Rust errors similarly to how Python handles exceptions in for loops. If an error occurs during iteration, the else clause is not executed.
-- **Collection Support**: Works with various Rust collections (Vec, HashMap, HashSet, etc.) and custom iterators.
+- **Optional Else Clause**: For both `for` and `while` loops, the `else` clause is executed if the loop completes without a `break` statement and without encountering a panic.
+- **`for` loop features**:
+    - **Inclusive/Exclusive Ranges**: Supports both inclusive (`..=`) and exclusive (`..`) ranges.
+    - **Step Values**: Allows specifying a step value for iteration, including negative steps for reverse iteration.
+    - **Collection Support**: Works with various Rust collections (Vec, HashMap, HashSet, etc.) and custom iterators.
+- **`while` loop features**:
+    - **Standard `while` and `do-while` variants**: Supports both common `while` loop forms.
+- **Error Handling**: Consistent panic handling for both loop types (else clause skipped).
+- **Break Statement Handling**: `break` statements within `pythonic_for!` or `pythonic_while!` bodies correctly prevent their respective `else` clauses from executing.
 
 ## Installation
 
@@ -20,10 +24,10 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pythonic-for = "0.1.0"
+pythonic-for = "0.1.0" # Replace with the latest version
 ```
 
-## Usage
+## `pythonic_for!` Macro
 
 ### Basic Usage Without Else Clause
 
@@ -32,14 +36,14 @@ use pythonic_for::pythonic_for;
 
 // Simple for loop without else clause
 let mut sum = 0;
-pythonic_for!((i in 0..5) {
+pythonic_for!(i in 0..5 {
     sum += i;
 });
 assert_eq!(sum, 10); // 0+1+2+3+4 = 10
 
 // For loop with step value without else clause
 let mut sum = 0;
-pythonic_for!((i in 0..10, step = 2) {
+pythonic_for!(i in 0..10, step = 2 {
     sum += i;
 });
 assert_eq!(sum, 20); // 0+2+4+6+8 = 20
@@ -47,36 +51,40 @@ assert_eq!(sum, 20); // 0+2+4+6+8 = 20
 
 ### Usage With Else Clause
 
+The `else` clause executes if the loop finishes normally (i.e., not via a `break` statement and no panics occurred).
+
 ```rust
 use pythonic_for::pythonic_for;
 
-// Basic for-else loop
-let mut found = false;
-pythonic_for!((i in 0..5) {
-    if i == 10 {
-        found = true;
+// Basic for-else loop (else executes)
+let mut found_val = -1;
+pythonic_for!(i in 0..5 {
+    if i == 10 { // Condition never met
+        found_val = i;
         break;
     }
 } else {
-    found = false;
+    // Loop completed without break
+    found_val = 100;
 });
-assert_eq!(found, false);
+assert_eq!(found_val, 100);
 
-// For loop with break
-let mut found = false;
-pythonic_for!((i in 0..5) {
+// For loop with break (else does not execute)
+let mut found_val_break = -1;
+pythonic_for!(i in 0..5 {
     if i == 3 {
-        found = true;
+        found_val_break = i;
         break;
     }
 } else {
-    found = false;
+    // This will not execute
+    found_val_break = 100;
 });
-assert_eq!(found, true);
+assert_eq!(found_val_break, 3);
 
 // Inclusive range
 let mut sum = 0;
-pythonic_for!((i in 1..=5) {
+pythonic_for!(i in 1..=5 {
     sum += i;
 } else {
     sum += 100;
@@ -85,7 +93,7 @@ assert_eq!(sum, 115); // 1+2+3+4+5+100 = 115
 
 // Step value
 let mut sum = 0;
-pythonic_for!((i in 0..10, step = 2) {
+pythonic_for!(i in 0..10, step = 2 {
     sum += i;
 } else {
     sum += 100;
@@ -94,7 +102,7 @@ assert_eq!(sum, 120); // 0+2+4+6+8+100 = 120
 
 // Negative step
 let mut sum = 0;
-pythonic_for!((i in 10..0, step = -2) {
+pythonic_for!(i in 10..0, step = -2 {
     sum += i;
 } else {
     sum += 100;
@@ -104,7 +112,7 @@ assert_eq!(sum, 130); // 10+8+6+4+2+100 = 130
 // Iterating over a collection
 let vec = vec![1, 2, 3, 4, 5];
 let mut sum = 0;
-pythonic_for!((i in vec) {
+pythonic_for!(i in vec {
     sum += i;
 } else {
     sum += 100;
@@ -117,6 +125,7 @@ assert_eq!(sum, 115); // 1+2+3+4+5+100 = 115
 The macro works with custom iterators as well:
 
 ```rust
+# use pythonic_for::pythonic_for;
 struct SquareIter {
     current: i32,
     end: i32,
@@ -139,7 +148,7 @@ impl Iterator for SquareIter {
 let square_iter = SquareIter { current: 1, end: 3 };
 let mut sum = 0;
 
-pythonic_for!((value in square_iter) {
+pythonic_for!(value in square_iter {
     sum += value;
 } else {
     sum += 100;
@@ -147,142 +156,334 @@ pythonic_for!((value in square_iter) {
 assert_eq!(sum, 114); // 1+4+9+100 = 114
 ```
 
-## Break Statements
-
-The `pythonic_for!` macro now automatically handles break statements without requiring any manual intervention:
-
-```rust
-pythonic_for!((i in 0..5) {
-    if i == 3 {
-        break; // Automatically sets _break_occurred internally
-    }
-} else {
-    // This will not execute if break was used
-});
-```
-
-## Common Pitfalls and Best Practices
-
-### Infinite Iterators
-
-When using infinite iterators like `cycle()` with an else clause, the else clause becomes unreachable unless you include a break statement:
-
-```rust
-// LOGICAL ERROR: The else clause will never execute
-pythonic_for!((n in numbers.iter().cycle()) {
-    // This will cycle through the collection indefinitely
-} else {
-    // This code is unreachable without a break in the loop body
-});
-
-// CORRECT: Use a break condition with infinite iterators
-pythonic_for!((n in numbers.iter().cycle()) {
-    // Process n
-    if some_condition {
-        break; // Exit condition makes the loop finite
-    }
-} else {
-    // Now this can be reached if the break condition is met
-});
-```
-
-### Nested Loops
-
-When using nested loops, only breaks in the outermost loop affect the else clause:
-
-```rust
-pythonic_for!((i in 0..3) {
-    for j in 0..3 {
-        if j == 1 {
-            break; // This only breaks from the inner loop
-        }
-    }
-} else {
-    // This will still execute since the break was in the inner loop
-});
-```
-
-### Error Handling
-
-For robust error handling, combine the pythonic_for macro with Result types:
-
-```rust
-let mut result: Result<i32, &str> = Ok(0);
-pythonic_for!((i in 0..5) {
-    match process(i) {
-        Ok(value) => { /* continue processing */ },
-        Err(e) => {
-            result = Err(e);
-            break; // Exit the loop on error
-        }
-    }
-} else {
-    // This only executes if no errors occurred
-});
-```
-
-## Iterator Adapters
+### Iterator Adapters
 
 The `pythonic_for!` macro works seamlessly with all standard Iterator adapters:
 
 ```rust
+# use pythonic_for::pythonic_for;
 // Using enumerate
 let letters = vec!['a', 'b', 'c'];
-pythonic_for!((pair in letters.iter().enumerate()) {
+let mut s = String::new();
+pythonic_for!(pair in letters.iter().enumerate() {
     let (idx, ch) = pair;
-    println!("Index: {}, Value: {}", idx, ch);
+    s.push_str(&format!("({},{})", idx, ch));
 });
+assert_eq!(s, "(0,a)(1,b)(2,c)");
 
 // Using take to limit iterations
 let numbers = vec![1, 2, 3, 4, 5, 6];
-pythonic_for!((n in numbers.iter().take(3)) {
-    // Only iterates over the first 3 elements
+let mut sum_take = 0;
+pythonic_for!(n in numbers.iter().take(3) {
+    sum_take += n;
 });
+assert_eq!(sum_take, 6); // 1+2+3
 
 // Using skip to start from a specific position
-pythonic_for!((n in numbers.iter().skip(2)) {
-    // Skips the first 2 elements
+let mut sum_skip = 0;
+pythonic_for!(n in numbers.iter().skip(2) {
+    sum_skip += n; // 3+4+5+6
 });
+assert_eq!(sum_skip, 18);
+
 
 // Using flat_map for nested collections
 let nested = vec![vec![1, 2], vec![3, 4]];
-pythonic_for!((n in nested.iter().flat_map(|v| v.iter())) {
-    // Flattens the nested structure
+let mut sum_flat = 0;
+pythonic_for!(n in nested.iter().flat_map(|v| v.iter()) {
+    sum_flat += n;
 });
+assert_eq!(sum_flat, 10); // 1+2+3+4
 
 // Using cycle with break for infinite iteration
-pythonic_for!((n in numbers.iter().cycle()) {
-    // Will cycle through the collection indefinitely
-    if some_condition {
-        break; // Use break to exit the loop
+let mut sum_cycle = 0;
+let mut count = 0;
+pythonic_for!(n in numbers.iter().cycle() {
+    sum_cycle += n;
+    count += 1;
+    if count >= 10 { // Iterate 10 times over 1,2,3,4,5,6...
+        break; 
     }
 });
+// (1+2+3+4+5+6) + (1+2+3+4) = 21 + 10 = 31
+assert_eq!(sum_cycle, 31); 
 
 // Other adapters like filter_map, chain, zip, etc. are also supported
 ```
 
-## Error Handling
+## `pythonic_while!` Macro
 
-The `pythonic_for!` macro supports two types of error handling:
+The `pythonic_while!` macro provides Python-style `while` loops, also with an optional `else` clause that executes if the loop terminates normally (not via `break` and no panics).
 
-1. **Panic handling**: If a panic occurs in the loop body, the else clause is skipped.
-
-2. **Result-based error handling**: You can use Result types with the macro:
+### Basic `while` loop
 
 ```rust
-let mut result: Result<i32, &str> = Ok(0);
-pythonic_for!((i in 0..5) {
-    if some_condition {
-        result = Err("Error occurred");
-        break;
+# use pythonic_for::pythonic_while;
+let mut count = 0;
+let mut sum = 0;
+pythonic_while!(count < 3; { // Condition
+    // Body
+    sum += count;
+    count += 1;
+});
+assert_eq!(sum, 3); // 0 + 1 + 2
+assert_eq!(count, 3);
+```
+
+### `while` loop with `else`
+
+```rust
+# use pythonic_for::pythonic_while;
+let mut count = 0;
+let mut sum = 0;
+pythonic_while!(count < 3; { // Condition
+    // Body
+    sum += count;
+    count += 1;
+} else {
+    // Else clause: executes because loop completed normally
+    sum += 100;
+});
+assert_eq!(sum, 103); // 0 + 1 + 2 + 100
+assert_eq!(count, 3);
+
+// With break
+let mut count_break = 0;
+let mut sum_break = 0;
+pythonic_while!(count_break < 5; {
+    if count_break == 2 {
+        break; // Loop terminates due to break
     }
-    // Process if Ok
-    if let Ok(val) = result {
-        result = Ok(val + i);
+    sum_break += count_break;
+    count_break += 1;
+} else {
+    // Else clause: does NOT execute
+    sum_break += 100;
+});
+assert_eq!(sum_break, 1); // 0 + 1
+assert_eq!(count_break, 2);
+```
+
+### `do-while` loop variants
+
+The `pythonic_while!` macro also supports a `do-while` style loop. The first block (do-body) always executes once. Then the condition is checked. If true, the second block (extra-body, or while-body) executes, and the loop continues.
+
+```rust
+# use pythonic_for::pythonic_while;
+// do { body1 } while condition; { body2 }
+let mut val = 0;
+let mut iterations = 0;
+pythonic_while!(do { // Do-body (always runs at least once)
+    val += 1; 
+} while val < 3; { // Condition (checked after do-body)
+    // Extra-body (runs if condition is true)
+    iterations += 1; 
+    val += 1; // Modify condition variable here or in do-body
+});
+// Iteration 1: do{val=1}, cond(1<3 true), extra{iter=1, val=2}
+// Iteration 2: do{val=3}, cond(3<3 false) -> loop ends
+assert_eq!(val, 3);
+assert_eq!(iterations, 1);
+
+
+// do-while with else
+let mut val_else = 0;
+let mut iterations_else = 0;
+let mut else_ran = false;
+pythonic_while!(do {
+    val_else += 1;
+} while val_else < 3; {
+    iterations_else += 1;
+    val_else += 1;
+    // Example break from extra_body
+    // if val_else == 2 { break; } 
+} else {
+    else_ran = true;
+});
+assert_eq!(val_else, 3);
+assert_eq!(iterations_else, 1);
+assert!(else_ran); // Else runs as loop terminated normally by condition
+```
+
+## Control Flow
+
+### Break Statements
+
+The `pythonic_for!` and `pythonic_while!` macros automatically handle `break` statements. A `break` inside the loop body will prevent the `else` clause from executing.
+
+```rust
+# use pythonic_for::pythonic_for;
+let mut sum = 0;
+pythonic_for!(i in 0..5 {
+    if i == 3 {
+        break; // Exits loop, else clause is skipped
+    }
+    sum += i;
+} else {
+    sum = 99; // This will not execute
+});
+assert_eq!(sum, 3); // 0+1+2
+```
+
+### Nested Loops
+
+-   **Native loop inside `pythonic_for!` / `pythonic_while!`**: A `break` inside a native inner loop (e.g., a standard Rust `for` or `while`) only breaks out of that inner native loop. The outer pythonic loop continues, and its `else` clause will execute if the pythonic loop itself completes normally.
+
+    ```rust
+    # use pythonic_for::pythonic_for;
+    let mut outer_sum = 0;
+    let mut inner_breaks = 0;
+    pythonic_for!(i in 0..2 { // Outer pythonic loop
+        outer_sum += i;
+        for j in 0..5 { // Inner native loop
+            if j == 1 {
+                inner_breaks += 1;
+                break; // This only breaks from the inner native loop
+            }
+        }
+    } else {
+        // This will still execute, as the pythonic_for loop completed normally.
+        outer_sum += 100;
+    });
+    assert_eq!(inner_breaks, 2); // Inner loop broke twice
+    assert_eq!(outer_sum, 101);  // 0 (i=0) + 1 (i=1) + 100 (else) = 101
+    ```
+
+-   **Nested `pythonic_for!` / `pythonic_while!` loops**: A `break` statement inside an inner *pythonic* loop will prevent its *own* `else` clause from executing. However, it does not automatically break the outer *pythonic* loop. The outer loop will continue its execution. If the outer loop completes normally (i.e., is not itself broken out of), its `else` clause will execute.
+
+    ```rust
+    # use pythonic_for::pythonic_for;
+    let mut outer_sum = 0;
+    let mut inner_sum = 0;
+    let mut outer_else_ran = false;
+    let mut inner_else_count = 0;
+
+    pythonic_for!(i in 0..2 { // Outer pythonic loop
+        outer_sum += i;
+        pythonic_for!(j in 0..3 { // Inner pythonic loop
+            inner_sum += j;
+            if i == 0 && j == 1 {
+                // Breaking only the inner pythonic loop
+                break; 
+            }
+        } else {
+            // Else for inner pythonic loop
+            // Will run if inner loop is not broken.
+            inner_else_count += 1; 
+        });
+        // Outer loop continues here
+    } else {
+        // Else for outer pythonic loop
+        outer_else_ran = true;
+        outer_sum += 100;
+    });
+
+    // Outer loop (i=0): outer_sum=0. 
+    //   Inner loop (j=0, j=1, break): inner_sum = 0+1=1. Inner else does not run.
+    // Outer loop (i=1): outer_sum=0+1=1.
+    //   Inner loop (j=0, j=1, j=2, completes normally): inner_sum = 1 + (0+1+2) = 1+3=4. Inner else runs. inner_else_count=1.
+    // Outer loop completes normally. Outer else runs: outer_else_ran=true, outer_sum = 1+100=101.
+    
+    assert_eq!(outer_sum, 101);
+    assert_eq!(inner_sum, 4);
+    assert_eq!(inner_else_count, 1); // Inner else ran once (for i=1)
+    assert!(outer_else_ran);
+    ```
+
+## Error Handling
+
+This crate provides consistent error handling mechanisms for both `pythonic_for!` and `pythonic_while!`.
+
+1.  **Panic Handling**: If a panic occurs within the body of a `pythonic_for!` or `pythonic_while!` loop, the execution of the loop is immediately halted. The `else` clause associated with that loop will **not** be executed. The panic will propagate as usual unless caught by an outer `std::panic::catch_unwind`.
+
+    ```rust
+    # use pythonic_for::pythonic_for;
+    # use std::panic;
+    let mut else_executed = false;
+    let result = panic::catch_unwind(|| {
+        pythonic_for!(i in 0..5 {
+            if i == 2 {
+                panic!("Simulated error!");
+            }
+        } else {
+            else_executed = true;
+        });
+    });
+
+    assert!(result.is_err()); // The panic was caught
+    assert!(!else_executed); // Else clause was skipped
+    ```
+
+2.  **Result-Based Error Handling**: For more controlled error management, you can use standard Rust `Result` types within the loop body. If an operation returns an `Err`, you can `break` from the loop. The `else` clause will not execute if the loop was terminated by a `break`.
+
+    ```rust
+    # use pythonic_for::pythonic_for;
+    fn process_item(item: i32) -> Result<i32, String> {
+        if item == 3 {
+            Err(format!("Failed on item {}", item))
+        } else {
+            Ok(item * 2)
+        }
+    }
+
+    let mut processed_sum = 0;
+    let mut operation_status: Result<(), String> = Ok(());
+    let mut else_ran = false;
+
+    pythonic_for!(i in 0..5 {
+        match process_item(i) {
+            Ok(value) => {
+                processed_sum += value;
+            }
+            Err(e) => {
+                operation_status = Err(e);
+                break; // Exit the loop on first error
+            }
+        }
+    } else {
+        // This only executes if all items were processed successfully (no break)
+        else_ran = true;
+    });
+
+    assert!(else_ran || operation_status.is_err()); // Else runs OR an error occurred
+    if operation_status.is_ok() {
+        assert!(else_ran);
+        assert_eq!(processed_sum, (0*2) + (1*2) + (2*2) + (4*2)); // 0+2+4+8 = 14
+    } else {
+        assert!(!else_ran);
+        assert_eq!(processed_sum, (0*2) + (1*2) + (2*2)); // 0+2+4 = 6, then item 3 errors
+        assert_eq!(operation_status, Err("Failed on item 3".to_string()));
+    }
+    ```
+
+## Common Pitfalls and Best Practices
+
+### Infinite Iterators with `pythonic_for!`
+
+When using infinite iterators (e.g., `std::iter::repeat` or `Iterator::cycle()`) with `pythonic_for!`, the `else` clause is generally unreachable unless a `break` condition is included within the loop body.
+
+```rust
+# use pythonic_for::pythonic_for;
+let data = [1,2,3];
+let mut iteration_count = 0;
+// LOGICAL ERROR if no break: The else clause might never execute with cycle()
+// pythonic_for!(n in data.iter().cycle() {
+//     // This will cycle through the collection indefinitely
+// } else {
+//     // This code is unreachable without a break in the loop body
+// });
+
+// CORRECT: Use a break condition with infinite iterators
+pythonic_for!(n in data.iter().cycle() {
+    iteration_count += 1;
+    if iteration_count > 5 { // Ensure the loop terminates
+        break; 
     }
 } else {
-    // This only executes if no error occurred and no break was used
+    // This is reachable if the break condition above was NOT met (which it will be here).
+    // If break is hit, this else is skipped.
 });
+assert_eq!(iteration_count, 6); // Loop runs 6 times (0..=5) then breaks.
 ```
 
 ## License

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,7 +7,7 @@ fn main() {
 
     println!("Example 1: Basic for loop without else clause");
     let mut sum = 0;
-    pythonic_for!((i in 0..5) {
+    pythonic_for!(i in 0..5 {
         println!("  Iteration: i = {}", i);
         sum += i;
     });
@@ -15,7 +15,7 @@ fn main() {
 
     println!("Example 2: Basic for loop with else clause");
     let mut sum = 0;
-    pythonic_for!((i in 0..5) {
+    pythonic_for!(i in 0..5 {
         println!("  Iteration: i = {}", i);
         sum += i;
     } else {
@@ -26,7 +26,7 @@ fn main() {
 
     println!("Example 3: For loop with break (else clause not executed)");
     let mut sum = 0;
-    pythonic_for!((i in 0..5) {
+    pythonic_for!(i in 0..5 {
         println!("  Iteration: i = {}", i);
         sum += i;
         if i == 2 {
@@ -41,7 +41,7 @@ fn main() {
 
     println!("Example 4: For loop with step value without else clause");
     let mut sum = 0;
-    pythonic_for!((i in 0..10, step = 2) {
+    pythonic_for!(i in 0..10, step = 2 {
         println!("  Iteration: i = {}", i);
         sum += i;
     });
@@ -49,7 +49,7 @@ fn main() {
 
     println!("Example 5: For loop with step value with else clause");
     let mut sum = 0;
-    pythonic_for!((i in 0..10, step = 2) {
+    pythonic_for!(i in 0..10, step = 2 {
         println!("  Iteration: i = {}", i);
         sum += i;
     } else {
@@ -60,7 +60,7 @@ fn main() {
 
     println!("Example 6: For loop with negative step");
     let mut sum = 0;
-    pythonic_for!((i in 10..0, step = -2) {
+    pythonic_for!(i in 10..0, step = -2 {
         println!("  Iteration: i = {}", i);
         sum += i;
     } else {
@@ -72,7 +72,7 @@ fn main() {
     println!("Example 7: Iterating over a collection without else clause");
     let vec = vec![1, 2, 3, 4, 5];
     let mut sum = 0;
-    pythonic_for!((i in vec) {
+    pythonic_for!(i in vec {
         println!("  Iteration: i = {}", i);
         sum += i;
     });
@@ -81,7 +81,7 @@ fn main() {
     println!("Example 8: Custom iterator");
     let square_iter = SquareIter { current: 1, end: 3 };
     let mut sum = 0;
-    pythonic_for!((value in square_iter) {
+    pythonic_for!(value in square_iter {
         println!("  Iteration: value = {}", value);
         sum += value;
     } else {
@@ -93,8 +93,8 @@ fn main() {
     println!("Example 9: Iterator adapter - enumerate");
     let letters = vec!['a', 'b', 'c'];
     let mut result = String::new();
-    pythonic_for!((pair in letters.iter().enumerate()) {
-        let (idx, ch) = pair;
+    pythonic_for!(pair in letters.iter().enumerate() {
+        let (idx, ch) = pair; // This pattern `pair` should be fine as `var_ident`
         println!("  Iteration: idx = {}, ch = {}", idx, ch);
         result.push_str(&format!("{}{}", idx, ch));
     } else {
@@ -106,9 +106,9 @@ fn main() {
     println!("Example 10: Iterator adapter - take");
     let numbers = vec![1, 2, 3, 4, 5, 6];
     let mut sum = 0;
-    pythonic_for!((n in numbers.iter().take(3)) {
+    pythonic_for!(n in numbers.iter().take(3) {
         println!("  Iteration: n = {}", n);
-        sum += *n;
+        sum += *n; // Assuming n is `&i32` if iter() is used, or `i32` if `into_iter()` implied
     } else {
         println!("  Else clause executed");
         sum += 100;
@@ -118,7 +118,7 @@ fn main() {
     println!("Example 11: Iterator adapter - skip");
     let numbers = vec![1, 2, 3, 4, 5];
     let mut sum = 0;
-    pythonic_for!((n in numbers.iter().skip(2)) {
+    pythonic_for!(n in numbers.iter().skip(2) {
         println!("  Iteration: n = {}", n);
         sum += *n;
     } else {
@@ -130,7 +130,7 @@ fn main() {
     println!("Example 12: Iterator adapter - flat_map");
     let nested = vec![vec![1, 2], vec![3, 4]];
     let mut sum = 0;
-    pythonic_for!((n in nested.iter().flat_map(|v| v.iter())) {
+    pythonic_for!(n in nested.iter().flat_map(|v| v.iter()) {
         println!("  Iteration: n = {}", n);
         sum += *n;
     } else {
@@ -143,7 +143,7 @@ fn main() {
     let numbers = vec![1, 2, 3];
     let mut sum = 0;
     let mut count = 0;
-    pythonic_for!((n in numbers.iter().cycle()) {
+    pythonic_for!(n in numbers.iter().cycle() {
         println!("  Iteration: n = {}", n);
         sum += *n;
         count += 1;
@@ -159,7 +159,7 @@ fn main() {
 
     println!("Example 14: Result-based error handling");
     let mut result: Result<i32, &str> = Ok(0);
-    pythonic_for!((i in 0..5) {
+    pythonic_for!(i in 0..5 {
         println!("  Iteration: i = {}", i);
         if i == 3 {
             println!("  Error at i = 3");
@@ -180,7 +180,7 @@ fn main() {
 
     println!("Example 15: Nested loops");
     let mut sum = 0;
-    pythonic_for!((i in 0..3) {
+    pythonic_for!(i in 0..3 {
         println!("  Outer loop: i = {}", i);
         
         for j in 0..3 {

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "pythonic-for-proc-macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Erkin Alp Güney <erkinalp9035@gmail.com>"]
-description = "Procedural macros for the pythonic-for crate"
+description = "Procedural macros for implementing Python-style for-else and while-else loops in the pythonic-for crate."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/erkinalp/pythonic-for"
+keywords = ["rust", "macros", "proc-macro", "pythonic-for"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [lib]
 proc-macro = true

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -1,124 +1,334 @@
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, Block, ExprBreak, visit_mut::{self, VisitMut}};
+use quote::{quote, format_ident};
+use syn::{
+    parse_macro_input, Block, ExprBreak, visit_mut::{self, VisitMut}, Token, Ident, Expr, Result,
+    parse::{Parse, ParseStream}, RangeLimits, Pat, Lifetime, Lit, ExprLit,
+};
+
+struct TransformBodyInput {
+    label: Lifetime,
+    _comma: Token![,],
+    body: Block,
+}
+
+impl Parse for TransformBodyInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            label: input.parse()?,
+            _comma: input.parse()?,
+            body: input.parse()?,
+        })
+    }
+}
 
 struct BreakTransformer {
-    loop_depth: usize,
-    in_pythonic_for: bool,
+    in_pythonic_loop_body: bool, 
+    current_loop_label: Lifetime,
 }
 
 impl BreakTransformer {
-    fn new() -> Self {
-        Self { 
-            loop_depth: 0,
-            in_pythonic_for: true,
+    fn new(loop_label: Lifetime) -> Self {
+        Self {
+            in_pythonic_loop_body: true, 
+            current_loop_label: loop_label,
         }
     }
 }
 
 impl VisitMut for BreakTransformer {
     fn visit_expr_for_loop_mut(&mut self, node: &mut syn::ExprForLoop) {
-        let was_in_pythonic_for = self.in_pythonic_for;
-        
-        if let Some(label) = &node.label {
-            let label_str = format!("{}", quote!(#label));
-            if label_str.contains("pythonic_for_loop") {
-                self.in_pythonic_for = true;
-            }
-        }
-        
-        self.loop_depth += 1;
+        let originally_in_pythonic_loop_body = self.in_pythonic_loop_body;
+        self.in_pythonic_loop_body = false; 
         visit_mut::visit_expr_for_loop_mut(self, node);
-        self.loop_depth -= 1;
-        
-        self.in_pythonic_for = was_in_pythonic_for;
+        self.in_pythonic_loop_body = originally_in_pythonic_loop_body; 
     }
 
     fn visit_expr_while_mut(&mut self, node: &mut syn::ExprWhile) {
-        let was_in_pythonic_for = self.in_pythonic_for;
-        
-        if let Some(label) = &node.label {
-            let label_str = format!("{}", quote!(#label));
-            if label_str.contains("pythonic_while_loop") {
-                self.in_pythonic_for = true;
-            }
-        }
-        
-        self.loop_depth += 1;
+        let originally_in_pythonic_loop_body = self.in_pythonic_loop_body;
+        self.in_pythonic_loop_body = false;
         visit_mut::visit_expr_while_mut(self, node);
-        self.loop_depth -= 1;
-        
-        self.in_pythonic_for = was_in_pythonic_for;
+        self.in_pythonic_loop_body = originally_in_pythonic_loop_body;
     }
 
     fn visit_expr_loop_mut(&mut self, node: &mut syn::ExprLoop) {
-        let was_in_pythonic_for = self.in_pythonic_for;
-        
-        if let Some(label) = &node.label {
-            let label_str = format!("{}", quote!(#label));
-            if label_str.contains("pythonic_while_loop") || label_str.contains("pythonic_for_loop") {
-                self.in_pythonic_for = true;
-            }
-        }
-        
-        self.loop_depth += 1;
+        let originally_in_pythonic_loop_body = self.in_pythonic_loop_body;
+        self.in_pythonic_loop_body = false;
         visit_mut::visit_expr_loop_mut(self, node);
-        self.loop_depth -= 1;
-        
-        self.in_pythonic_for = was_in_pythonic_for;
+        self.in_pythonic_loop_body = originally_in_pythonic_loop_body;
     }
+    
+    fn visit_expr_mut(&mut self, node: &mut Expr) {
+        if let Expr::Break(expr_break) = node {
+            if self.in_pythonic_loop_body {
+                let user_label = &expr_break.label;
+                let break_expr_val = &expr_break.expr;
 
-    fn visit_expr_break_mut(&mut self, node: &mut ExprBreak) {
-        if self.in_pythonic_for {
-            let label = &node.label;
-            let expr = &node.expr;
+                let target_label_to_quote = match user_label {
+                    Some(l) => quote!(#l),
+                    None => {
+                        let l = &self.current_loop_label;
+                        quote!(#l)
+                    }
+                };
             
-            let new_expr = if let Some(label) = label {
-                if let Some(expr) = expr {
+                let new_expr_tokens = if let Some(inner_expr) = break_expr_val {
                     quote! {{
                         _break_occurred = true;
-                        break #label #expr;
+                        break #target_label_to_quote #inner_expr;
                     }}
                 } else {
                     quote! {{
                         _break_occurred = true;
-                        break #label;
+                        break #target_label_to_quote;
                     }}
-                }
-            } else if let Some(expr) = expr {
-                quote! {{
-                    _break_occurred = true;
-                    break #expr;
-                }}
-            } else {
-                quote! {{
-                    _break_occurred = true;
-                    break;
-                }}
-            };
-            
-            match syn::parse2(new_expr) {
-                Ok(new_node) => *node = new_node,
-                Err(e) => {
-                    eprintln!("Failed to transform break statement: {}", e);
+                };
+                
+                match syn::parse2::<Expr>(new_expr_tokens) {
+                    Ok(new_expr_block) => {
+                        *node = new_expr_block; 
+                        return; 
+                    }
+                    Err(e) => {
+                        let error_ts = syn::Error::new_spanned(
+                            node, // Span of the original break expression node
+                            format!("Internal error in pythonic-for: Failed to construct break transformation: {}", e)
+                        ).to_compile_error();
+                        // Try to parse the compile_error! invocation itself as an Expr
+                        match syn::parse2::<Expr>(error_ts) {
+                           Ok(err_expr) => *node = err_expr, // Replace node with the compile_error! expression
+                           Err(_) => { /* Last resort: if parsing compile_error! itself fails, leave node unchanged or panic */ }
+                        }
+                        return;
+                    }
                 }
             }
         }
-        
-        visit_mut::visit_expr_break_mut(self, node);
+        // Default visitation for other expressions or if not transformed
+        visit_mut::visit_expr_mut(self, node);
     }
 }
 
+
 #[proc_macro]
 pub fn transform_body(input: TokenStream) -> TokenStream {
-    let mut block = parse_macro_input!(input as Block);
+    // This parses `label, { body }`
+    let parsed = match syn::parse::<TransformBodyInput>(input.clone()) {
+        Ok(p) => p,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let mut body_block = parsed.body;
+    let loop_label = parsed.label;
     
-    let mut transformer = BreakTransformer::new();
-    transformer.visit_block_mut(&mut block);
+    let mut transformer = BreakTransformer::new(loop_label);
+    transformer.visit_block_mut(&mut body_block);
     
     let expanded = quote! {
-        #block
+        #body_block
     };
     
     expanded.into()
+}
+
+mod kw {
+    syn::custom_keyword!(in_kw);
+    syn::custom_keyword!(else_kw);
+    syn::custom_keyword!(step);
+}
+
+struct StepClause {
+    step_kw: kw::step,
+    eq_token: Token![=],
+    step_expr: Expr,
+}
+
+impl Parse for StepClause {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            step_kw: input.parse()?,
+            eq_token: input.parse()?,
+            step_expr: input.parse()?,
+        })
+    }
+}
+
+enum Iterable {
+    Expr(Expr), 
+    RangeWithStep {
+        range_expr: Expr, 
+        comma_token: Token![,],
+        step_clause: StepClause,
+    },
+}
+
+impl Parse for Iterable {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let expr: Expr = input.parse()?;
+        if input.peek(Token![,]) && input.peek2(kw::step) {
+            Ok(Iterable::RangeWithStep {
+                range_expr: expr, 
+                comma_token: input.parse()?,
+                step_clause: input.parse()?,
+            })
+        } else {
+            Ok(Iterable::Expr(expr))
+        }
+    }
+}
+
+struct ElseClause {
+    else_kw: kw::else_kw,
+    else_body: Block,
+}
+
+impl Parse for ElseClause {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(ElseClause {
+            else_kw: input.parse()?,
+            else_body: input.parse()?,
+        })
+    }
+}
+
+struct PythonicForInput {
+    var: Ident,
+    in_kw: kw::in_kw,
+    iterable: Iterable,
+    body: Block,
+    else_clause: Option<ElseClause>,
+}
+
+impl Parse for PythonicForInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let var_pat: Pat = input.parse()?;
+        let var = match var_pat {
+            Pat::Ident(pat_ident) => {
+                if !pat_ident.attrs.is_empty() || pat_ident.by_ref.is_some() || pat_ident.mutability.is_some() || pat_ident.subpat.is_some() {
+                     return Err(syn::Error::new_spanned(pat_ident, "Loop variable must be a simple identifier (e.g., `i`), not a complex pattern."));
+                }
+                pat_ident.ident
+            }
+            _ => return Err(syn::Error::new_spanned(var_pat, "Expected a simple identifier for the loop variable (e.g., `i`). Patterns are not supported here.")),
+        };
+        
+        let in_kw: kw::in_kw = input.parse()?;
+        let iterable: Iterable = input.parse()?;
+        let body: Block = input.parse()?;
+        
+        let else_clause: Option<ElseClause> = if input.peek(kw::else_kw) {
+            Some(input.parse()?)
+        } else {
+            None
+        };
+
+        Ok(PythonicForInput {
+            var,
+            in_kw,
+            iterable,
+            body,
+            else_clause,
+        })
+    }
+}
+
+
+#[proc_macro]
+pub fn pythonic_for(input: TokenStream) -> TokenStream {
+    let parsed_input = match syn::parse::<PythonicForInput>(input) {
+        Ok(pi) => pi,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let var_ident = parsed_input.var;
+    let user_body = parsed_input.body;
+    
+    // Create a unique label for this specific loop invocation
+    let loop_label_str = format!("pythonic_for_loop_{}", var_ident); 
+    let loop_label = Lifetime::new(&loop_label_str, var_ident.span());
+
+
+    let loop_logic = match parsed_input.iterable {
+        Iterable::Expr(iterable_expr) => {
+            quote! {
+                #loop_label: for #var_ident in #iterable_expr {
+                    pythonic_for_proc_macros::transform_body!(#loop_label, { #user_body })
+                }
+            }
+        }
+        Iterable::RangeWithStep { range_expr, step_clause, .. } => {
+            let (start_expr, end_expr, inclusive) = match range_expr {
+                Expr::Range(expr_range) => {
+                    let start = expr_range.start.as_deref();
+                    let end = expr_range.end.as_deref();
+                    let limits = expr_range.limits;
+
+                    if start.is_none() {
+                        return syn::Error::new_spanned(&expr_range, "Range must have a start value for stepped iteration.")
+                                        .to_compile_error().into();
+                    }
+                    if end.is_none() {
+                         return syn::Error::new_spanned(&expr_range, "Range must have an end value for stepped iteration.")
+                                        .to_compile_error().into();
+                    }
+                    (start.unwrap().clone(), end.unwrap().clone(), matches!(limits, RangeLimits::Closed(_)))
+                }
+                ref other_expr => {
+                    return syn::Error::new_spanned(
+                        other_expr,
+                        "Expected a range expression (e.g., `0..10` or `1..=5`) when 'step' is used."
+                    ).to_compile_error().into();
+                }
+            };
+            
+            let step_val_expr = step_clause.step_expr;
+            quote! {
+                let __start = #start_expr;
+                let __end = #end_expr;
+                let __step = #step_val_expr;
+                let mut __current = __start;
+
+                if __step == 0 {
+                    // TODO: Consider compile_error! or specific runtime panic for step = 0.
+                }
+
+                if __step > 0 {
+                    #loop_label: while if #inclusive { __current <= __end } else { __current < __end } {
+                        let #var_ident = __current;
+                        pythonic_for_proc_macros::transform_body!(#loop_label, { #user_body })
+                        __current += __step;
+                    }
+                } else if __step < 0 {
+                    #loop_label: while if #inclusive { __current >= __end } else { __current > __end } {
+                        let #var_ident = __current;
+                        pythonic_for_proc_macros::transform_body!(#loop_label, { #user_body })
+                        __current += __step; 
+                    }
+                }
+                // If step is 0, and range is not empty, it's an infinite loop.
+            }
+        }
+    };
+
+    let else_block_logic = if let Some(else_c) = parsed_input.else_clause {
+        let else_body_content = else_c.else_body;
+        quote! {
+            if !_break_occurred && __result.is_ok() {
+                #else_body_content
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let final_code = quote! {
+        {
+            let mut _break_occurred = false;
+            let __result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                #loop_logic
+            }));
+            
+            #else_block_logic
+        }
+    };
+
+    final_code.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! // Basic for-else loop - no break occurs, so else clause executes
 //! let mut found = false;
-//! pythonic_for!((i in 0..5) {
+//! pythonic_for!(i in 0..5 {
 //!     if i == 10 { // This condition never matches in range 0..5
 //!         found = true;
 //!         break;
@@ -24,26 +24,26 @@
 //!
 //! // For loop without else clause
 //! let mut sum = 0;
-//! pythonic_for!((i in 0..5) {
+//! pythonic_for!(i in 0..5 {
 //!     sum += i;
 //! });
 //! assert_eq!(sum, 10); // 0+1+2+3+4 = 10
 //!
 //! // For loop with break - break occurs, so else clause doesn't execute
 //! let mut found = false;
-//! pythonic_for!((i in 0..5) {
+//! pythonic_for!(i in 0..5 {
 //!     if i == 3 { // This condition matches when i is 3
 //!         found = true;
 //!         break;
 //!     }
 //! } else {
-//!     found = false; // This won't execute because of the break
+//!     // This found = false should not be executed.
 //! });
 //! assert_eq!(found, true);
 //!
 //! // Inclusive range
 //! let mut sum = 0;
-//! pythonic_for!((i in 1..=5) {
+//! pythonic_for!(i in 1..=5 {
 //!     sum += i;
 //! } else {
 //!     sum += 100;
@@ -52,7 +52,7 @@
 //!
 //! // Step value
 //! let mut sum = 0;
-//! pythonic_for!((i in 0..10, step = 2) {
+//! pythonic_for!(i in 0..10, step = 2 {
 //!     sum += i;
 //! } else {
 //!     sum += 100;
@@ -61,7 +61,7 @@
 //!
 //! // Negative step
 //! let mut sum = 0;
-//! pythonic_for!((i in 10..0, step = -2) {
+//! pythonic_for!(i in 10..0, step = -2 {
 //!     sum += i;
 //! } else {
 //!     sum += 100;
@@ -71,7 +71,7 @@
 //! // Iterating over a collection
 //! let vec = vec![1, 2, 3, 4, 5];
 //! let mut sum = 0;
-//! pythonic_for!((i in vec) {
+//! pythonic_for!(i in vec {
 //!     sum += i;
 //! } else {
 //!     sum += 100;
@@ -110,14 +110,14 @@
 ///
 /// // Basic for loop without else clause
 /// let mut sum = 0;
-/// pythonic_for!((i in 0..5) {
+/// pythonic_for!(i in 0..5 {
 ///     sum += i;
 /// });
 /// assert_eq!(sum, 10); // 0+1+2+3+4 = 10
 ///
 /// // Basic for loop with else clause
 /// let mut sum = 0;
-/// pythonic_for!((i in 0..5) {
+/// pythonic_for!(i in 0..5 {
 ///     sum += i;
 /// } else {
 ///     sum += 100;
@@ -126,7 +126,7 @@
 ///
 /// // For loop with range and step
 /// let mut sum2 = 0;
-/// pythonic_for!((i in 0..10, step = 2) {
+/// pythonic_for!(i in 0..10, step = 2 {
 ///     sum2 += i;
 /// } else {
 ///     sum2 += 100;
@@ -135,7 +135,7 @@
 ///
 /// // For loop with inclusive range
 /// let mut sum3 = 0;
-/// pythonic_for!((i in 1..=5) {
+/// pythonic_for!(i in 1..=5 {
 ///     sum3 += i;
 /// } else {
 ///     sum3 += 100;
@@ -164,14 +164,14 @@
 /// // This will panic during iteration when i == 3
 /// let result_with_error = panic::catch_unwind(panic::AssertUnwindSafe(|| {
 ///     let mut inner_result = 0;
-///     pythonic_for!((i in 0..5) {
+///     pythonic_for!(i in 0..5 {
 ///         if i == 3 {
 ///             // Simulate an error
 ///             panic!("Error during iteration");
 ///         }
 ///         inner_result += i;
 ///     } else {
-///         inner_result = 100;
+///         inner_result = 100; // This should not execute
 ///     });
 ///     // Update the outer result
 ///     result = inner_result;
@@ -179,423 +179,131 @@
 ///
 /// // The else clause is not executed because an error occurred
 /// assert!(result_with_error.is_err());
-/// // result remains 0 because the panic occurred
-/// assert_eq!(result, 0);
+/// // result remains 0 because the panic occurred (or whatever value it had before the panic in pythonic_for scope)
+/// // Assuming inner_result is not assigned back to result if panic happens.
+/// // The exact value of `result` depends on how `pythonic_for` handles assignments before panic.
+/// // With `catch_unwind`, `result` would retain its value from before `pythonic_for` if `inner_result` isn't assigned.
+/// // If `pythonic_for` is a block expression, `result` would be assigned the outcome of that block.
+/// // The current `pythonic_for` doesn't return a value, it's a statement.
+/// // So `result` would be unchanged (0) if panic occurs before `result = inner_result;`
+/// assert_eq!(result, 0); 
 /// ```
-#[macro_export]
-macro_rules! pythonic_for {
-    // For iterating over any iterable without an else clause
-    (($var:ident in $iterable:expr) $body:block) => {
-        {
-            let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                'pythonic_for_loop: for $var in $iterable {
-                    $crate::_internal_pythonic_for_body!($body);
-                    
-                    if _break_occurred {
-                        break 'pythonic_for_loop;
-                    }
-                }
-            }));
-
-            if result.is_err() {
-                _error_occurred = true;
-            }
-        }
-    };
-
-    // For iterating over any iterable with an else clause
-    (($var:ident in $iterable:expr) $body:block else $else_body:block) => {
-        {
-            let mut _cycle_detected = false;
-            {
-                let iter_ref = &$iterable;
-                _cycle_detected = $crate::_is_likely_cycle(iter_ref);
-            }
-            
-            if _cycle_detected {
-                $crate::_warn_cycle_with_else();
-            }
-            
-            let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                'pythonic_for_loop: for $var in $iterable {
-                    $crate::_internal_pythonic_for_body!($body);
-                    
-                    if _break_occurred {
-                        break 'pythonic_for_loop;
-                    }
-                }
-            }));
-
-            if result.is_err() {
-                _error_occurred = true;
-            }
-
-            // Execute the else body only if no break occurred and no error occurred
-            if !_break_occurred && !_error_occurred {
-                $else_body
-            }
-        }
-    };
-
-    // For iterating over a range with a step without an else clause
-    (($var:ident in $range:expr, step = $step:expr) $body:block) => {
-        {
-            let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let step = $step;
-                let range = $range;
-
-                let is_inclusive = {
-                    let range_str = format!("{:?}", range);
-                    range_str.contains("=")
-                };
-
-                if step > 0 {
-                    // Forward iteration with positive step
-                    let start = range.start;
-                    let end = range.end;
-                    let mut current = start;
-
-                    'pythonic_for_loop: while if is_inclusive { current <= end } else { current < end } {
-                        let $var = current;
-                        
-                        // Execute the loop body
-                        let _result = (|| {
-                            #[allow(unused_labels)]
-                            'inner: {
-                                $crate::_internal_pythonic_for_body!($body);
-                            }
-                        })();
-                        
-                        if _break_occurred {
-                            break 'pythonic_for_loop;
-                        }
-                        
-                        current += step;
-                    }
-                } else if step < 0 {
-                    // Reverse iteration with negative step
-                    let start = range.start;
-                    let end = range.end;
-                    let mut current = start;
-
-                    'pythonic_for_loop: while if is_inclusive { current >= end } else { current > end } {
-                        let $var = current;
-                        
-                        // Execute the loop body
-                        let _result = (|| {
-                            #[allow(unused_labels)]
-                            'inner: {
-                                $crate::_internal_pythonic_for_body!($body);
-                            }
-                        })();
-                        
-                        if _break_occurred {
-                            break 'pythonic_for_loop;
-                        }
-                        
-                        current += step;
-                    }
-                }
-            }));
-
-            if result.is_err() {
-                _error_occurred = true;
-            }
-        }
-    };
-
-    // For iterating over a range with a step with an else clause
-    (($var:ident in $range:expr, step = $step:expr) $body:block else $else_body:block) => {
-        {
-            let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let step = $step;
-                let range = $range;
-
-                let is_inclusive = {
-                    let range_str = format!("{:?}", range);
-                    range_str.contains("=")
-                };
-
-                if step > 0 {
-                    // Forward iteration with positive step
-                    let start = range.start;
-                    let end = range.end;
-                    let mut current = start;
-
-                    'pythonic_for_loop: while if is_inclusive { current <= end } else { current < end } {
-                        let $var = current;
-                        
-                        // Execute the loop body
-                        let _result = (|| {
-                            #[allow(unused_labels)]
-                            'inner: {
-                                $crate::_internal_pythonic_for_body!($body);
-                            }
-                        })();
-                        
-                        if _break_occurred {
-                            break 'pythonic_for_loop;
-                        }
-                        
-                        current += step;
-                    }
-                } else if step < 0 {
-                    // Reverse iteration with negative step
-                    let start = range.start;
-                    let end = range.end;
-                    let mut current = start;
-
-                    'pythonic_for_loop: while if is_inclusive { current >= end } else { current > end } {
-                        let $var = current;
-                        
-                        // Execute the loop body
-                        let _result = (|| {
-                            #[allow(unused_labels)]
-                            'inner: {
-                                $crate::_internal_pythonic_for_body!($body);
-                            }
-                        })();
-                        
-                        if _break_occurred {
-                            break 'pythonic_for_loop;
-                        }
-                        
-                        current += step;
-                    }
-                }
-            }));
-
-            if result.is_err() {
-                _error_occurred = true;
-            }
-
-            // Execute the else body only if no break occurred and no error occurred
-            if !_break_occurred && !_error_occurred {
-                $else_body
-            }
-        }
-    };
-
-    (($var:ident in $iterable:expr) { $($body:tt)* }) => {
-        pythonic_for!(($var in $iterable) { $($body)* })
-    };
-
-    (($var:ident in $iterable:expr) { $($body:tt)* } else $else_body:block) => {
-        pythonic_for!(($var in $iterable) { $($body)* } else $else_body)
-    };
-
-    (($var:ident in $range:expr, step = $step:expr) { $($body:tt)* }) => {
-        pythonic_for!(($var in $range, step = $step) { $($body)* })
-    };
-
-    (($var:ident in $range:expr, step = $step:expr) { $($body:tt)* } else $else_body:block) => {
-        pythonic_for!(($var in $range, step = $step) { $($body)* } else $else_body)
-    };
-}
+// Re-export the procedural macro
+pub use pythonic_for_proc_macros::pythonic_for;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::*; 
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 
     #[test]
     fn test_basic_for_else() {
         let mut found = false;
-
-        {
-            let mut _break_occurred = false;
-
-            'pythonic_for_loop: for i in 0..5 {
-                if i == 10 {
-                    found = true;
-                    _break_occurred = true;
-                    break 'pythonic_for_loop;
-                }
+        pythonic_for!(i in 0..5 {
+            if i == 10 { 
+                found = true;
+                break;
             }
-
-            if !_break_occurred {
-                found = false;
-            }
-        }
-
+        } else {
+            found = false; 
+        });
         assert_eq!(found, false);
     }
 
     #[test]
     fn test_for_without_else() {
         let mut sum = 0;
-
-        pythonic_for!((i in 0..5) {
+        pythonic_for!(i in 0..5 {
             sum += i;
         });
-
-        assert_eq!(sum, 10); // 0+1+2+3+4 = 10
+        assert_eq!(sum, 10);
     }
 
     #[test]
     fn test_for_with_break() {
         let mut found = false;
-
-        {
-            let mut _break_occurred = false;
-
-            'pythonic_for_loop: for i in 0..5 {
-                if i == 3 {
-                    found = true;
-                    _break_occurred = true;
-                    break 'pythonic_for_loop;
-                }
+        pythonic_for!(i in 0..5 {
+            if i == 3 { 
+                found = true;
+                break;
             }
-
-            if !_break_occurred {
-                found = false;
-            }
-        }
-
-        assert_eq!(found, true);
+        } else {
+            // This part should not execute
+        });
+        assert_eq!(found, true); 
     }
-
+    
     #[test]
     fn test_inclusive_range() {
         let mut sum = 0;
-
-        {
-            let mut _break_occurred = false;
-
-            'pythonic_for_loop: for i in 1..=5 {
-                sum += i;
-            }
-
-            if !_break_occurred {
-                sum += 100;
-            }
-        }
-
-        assert_eq!(sum, 115); // 1+2+3+4+5+100 = 115
+        pythonic_for!(i in 1..=5 {
+            sum += i;
+        } else {
+            sum += 100;
+        });
+        assert_eq!(sum, 115);
     }
 
     #[test]
     fn test_step_value() {
         let mut sum = 0;
-
-        {
-            let mut _break_occurred = false;
-
-            'pythonic_for_loop: {
-                let step = 2;
-                let range = 0..10;
-                let start = range.start;
-                let end = range.end;
-                let mut current = start;
-
-                while current < end {
-                    let i = current;
-                    sum += i;
-                    current += step;
-                }
-            }
-
-            if !_break_occurred {
-                sum += 100;
-            }
-        }
-
-        assert_eq!(sum, 120); // 0+2+4+6+8+100 = 120
+        pythonic_for!(i in 0..10, step = 2 {
+            sum += i;
+        } else {
+            sum += 100;
+        });
+        assert_eq!(sum, 120); 
     }
 
     #[test]
     fn test_step_value_without_else() {
         let mut sum = 0;
-
-        pythonic_for!((i in 0..10, step = 2) {
+        pythonic_for!(i in 0..10, step = 2 {
             sum += i;
         });
-
-        assert_eq!(sum, 20); // 0+2+4+6+8 = 20
+        assert_eq!(sum, 20); 
     }
 
     #[test]
     fn test_negative_step() {
         let mut sum = 0;
-
-        {
-            let mut _break_occurred = false;
-
-            'pythonic_for_loop: {
-                let step = -2;
-                let range = 10..0;
-                let start = range.start;
-                let end = range.end;
-                let mut current = start;
-
-                while current > end {
-                    let i = current;
-                    sum += i;
-                    current += step;
-                }
-            }
-
-            if !_break_occurred {
-                sum += 100;
-            }
-        }
-
-        assert_eq!(sum, 130); // 10+8+6+4+2+100 = 130
+        pythonic_for!(i in 10..0, step = -2 {
+            sum += i;
+        } else {
+            sum += 100;
+        });
+        assert_eq!(sum, 130); 
     }
 
     #[test]
     fn test_negative_step_without_else() {
         let mut sum = 0;
-
-        pythonic_for!((i in 10..0, step = -2) {
+        pythonic_for!(i in 10..0, step = -2 {
             sum += i;
         });
-
-        assert_eq!(sum, 30); // 10+8+6+4+2 = 30
+        assert_eq!(sum, 30); 
     }
 
     #[test]
     fn test_iterable() {
         let vec = vec![1, 2, 3, 4, 5];
         let mut sum = 0;
-
-        {
-            let mut _break_occurred = false;
-
-            'pythonic_for_loop: for i in vec {
-                sum += i;
-            }
-
-            if !_break_occurred {
-                sum += 100;
-            }
-        }
-
-        assert_eq!(sum, 115); // 1+2+3+4+5+100 = 115
+        pythonic_for!(i in vec { 
+            sum += i;
+        } else {
+            sum += 100;
+        });
+        assert_eq!(sum, 115); 
     }
 
     #[test]
     fn test_iterable_without_else() {
         let vec = vec![1, 2, 3, 4, 5];
         let mut sum = 0;
-
-        pythonic_for!((i in vec) {
+        pythonic_for!(i in vec.iter() { 
             sum += i;
         });
-
-        assert_eq!(sum, 15); // 1+2+3+4+5 = 15
+        assert_eq!(sum, 15);
     }
 
     #[test]
@@ -606,14 +314,12 @@ mod tests {
         map.insert("three", 3);
 
         let mut sum = 0;
-
-        pythonic_for!((entry in map) {
+        pythonic_for!(entry in map {
             sum += entry.1;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 106); // 1+2+3+100 = 106
+        assert_eq!(sum, 106);
     }
 
     #[test]
@@ -624,14 +330,12 @@ mod tests {
         set.insert(15);
 
         let mut sum = 0;
-
-        pythonic_for!((value in set) {
+        pythonic_for!(value in set {
             sum += value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 130); // 5+10+15+100 = 130
+        assert_eq!(sum, 130);
     }
 
     #[test]
@@ -642,14 +346,12 @@ mod tests {
         deque.push_back(3);
 
         let mut sum = 0;
-
-        pythonic_for!((value in deque) {
+        pythonic_for!(value in deque {
             sum += value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 106); // 1+2+3+100 = 106
+        assert_eq!(sum, 106);
     }
 
     #[test]
@@ -660,14 +362,12 @@ mod tests {
         map.insert("c", 3);
 
         let mut sum = 0;
-
-        pythonic_for!((entry in map) {
+        pythonic_for!(entry in map {
             sum += entry.1;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 106); // 1+2+3+100 = 106
+        assert_eq!(sum, 106);
     }
 
     #[test]
@@ -678,14 +378,12 @@ mod tests {
         set.insert(15);
 
         let mut sum = 0;
-
-        pythonic_for!((value in set) {
+        pythonic_for!(value in set {
             sum += value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 130); // 5+10+15+100 = 130
+        assert_eq!(sum, 130);
     }
 
     #[test]
@@ -697,7 +395,6 @@ mod tests {
 
         impl Iterator for SquareIter {
             type Item = i32;
-
             fn next(&mut self) -> Option<Self::Item> {
                 if self.current <= self.end {
                     let result = self.current * self.current;
@@ -711,68 +408,52 @@ mod tests {
 
         let square_iter = SquareIter { current: 1, end: 3 };
         let mut sum = 0;
-
-        pythonic_for!((value in square_iter) {
+        pythonic_for!(value in square_iter {
             sum += value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 114); // 1+4+9+100 = 114
+        assert_eq!(sum, 114);
     }
 
     #[test]
     fn test_filter_map() {
         let numbers = vec![1, 2, 3, 4, 5];
         let mut sum = 0;
-
-        let even_doubles =
-            numbers
-                .iter()
-                .filter_map(|&x| if x % 2 == 0 { Some(x * 2) } else { None });
-
-        pythonic_for!((value in even_doubles) {
+        let even_doubles = numbers.iter().filter_map(|&x| if x % 2 == 0 { Some(x * 2) } else { None });
+        pythonic_for!(value in even_doubles {
             sum += value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 112); // 4+8+100 = 112
+        assert_eq!(sum, 112);
     }
 
     #[test]
     fn test_chain_iterator() {
         let first = vec![1, 2, 3];
         let second = vec![4, 5, 6];
-
         let mut sum = 0;
-
         let chained = first.iter().chain(second.iter());
-
-        pythonic_for!((value in chained) {
+        pythonic_for!(value in chained {
             sum += *value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 121); // 1+2+3+4+5+6+100 = 121
+        assert_eq!(sum, 121);
     }
 
     #[test]
     fn test_zip_iterator() {
         let numbers = vec![1, 2, 3];
         let letters = vec!['a', 'b', 'c'];
-
         let mut result = String::new();
-
         let zipped = numbers.iter().zip(letters.iter());
-
-        pythonic_for!((pair in zipped) {
+        pythonic_for!(pair in zipped {
             result.push_str(&format!("{}{}", pair.0, pair.1));
         } else {
             result.push_str("done");
         });
-
         assert_eq!(result, "1a2b3cdone");
     }
 
@@ -780,15 +461,12 @@ mod tests {
     fn test_enumerate_iterator() {
         let letters = vec!['a', 'b', 'c'];
         let mut result = String::new();
-
         let enumerated = letters.iter().enumerate();
-
-        pythonic_for!((pair in enumerated) {
+        pythonic_for!(pair in enumerated {
             result.push_str(&format!("{}{}", pair.0, pair.1));
         } else {
             result.push_str("done");
         });
-
         assert_eq!(result, "0a1b2cdone");
     }
 
@@ -796,48 +474,39 @@ mod tests {
     fn test_take_iterator() {
         let numbers = vec![1, 2, 3, 4, 5];
         let mut sum = 0;
-
         let taken = numbers.iter().take(3);
-
-        pythonic_for!((value in taken) {
+        pythonic_for!(value in taken {
             sum += *value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 106); // 1+2+3+100 = 106
+        assert_eq!(sum, 106);
     }
 
     #[test]
     fn test_skip_iterator() {
         let numbers = vec![1, 2, 3, 4, 5];
         let mut sum = 0;
-
         let skipped = numbers.iter().skip(2);
-
-        pythonic_for!((value in skipped) {
+        pythonic_for!(value in skipped {
             sum += *value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 112); // 3+4+5+100 = 112
+        assert_eq!(sum, 112);
     }
 
     #[test]
     fn test_flat_map_iterator() {
         let nested = vec![vec![1, 2], vec![3, 4]];
         let mut sum = 0;
-
         let flattened = nested.iter().flat_map(|v| v.iter());
-
-        pythonic_for!((value in flattened) {
+        pythonic_for!(value in flattened {
             sum += *value;
         } else {
             sum += 100;
         });
-
-        assert_eq!(sum, 110); // 1+2+3+4+100 = 110
+        assert_eq!(sum, 110);
     }
 
     #[test]
@@ -845,27 +514,22 @@ mod tests {
         let mut sum = 0;
         let mut outer_count = 0;
         let mut inner_breaks = 0;
-        
-        pythonic_for!((i in 0..3) {
+        pythonic_for!(i in 0..3 {
             outer_count += 1;
-            
-            for j in 0..3 {
+            for j in 0..3 { // Native for loop
                 sum += i * j;
-                
                 if j == 1 {
                     inner_breaks += 1;
-                    break;
+                    break; // Breaks native for loop
                 }
             }
-            
-            if i == 1 {
+            if i == 1 { // This break is for pythonic_for!
                 break;
             }
         });
-        
-        assert_eq!(outer_count, 2);
-        assert_eq!(inner_breaks, 2);
-        assert_eq!(sum, 1);
+        assert_eq!(outer_count, 2); // i=0, i=1
+        assert_eq!(inner_breaks, 2); // j loop breaks for i=0 and i=1
+        assert_eq!(sum, 1); // i=0: sum=0*0=0; i=1: sum=0 + 1*0 + 1*1=1
     }
     
     #[test]
@@ -874,31 +538,26 @@ mod tests {
         let mut outer_count = 0;
         let mut inner_breaks = 0;
         let mut else_executed = false;
-        
-        pythonic_for!((i in 0..3) {
+        pythonic_for!(i in 0..3 {
             outer_count += 1;
-            
-            for j in 0..3 {
+            for j in 0..3 { // Native for loop
                 sum += i * j;
-                
                 if j == 1 {
                     inner_breaks += 1;
-                    break;
+                    break; // Breaks native for loop
                 }
             }
-            
-            if i == 1 {
-                break;
+            if i == 1 { // This break is for pythonic_for!
+                break; 
             }
         } else {
             else_executed = true;
             sum += 100;
         });
-        
-        assert_eq!(outer_count, 2);
-        assert_eq!(inner_breaks, 2);
-        assert_eq!(sum, 101);
-        assert_eq!(else_executed, true);
+        assert_eq!(outer_count, 2); // i=0, i=1
+        assert_eq!(inner_breaks, 2); // j loop breaks for i=0 and i=1
+        assert_eq!(sum, 1); // Outer else should NOT execute due to `break` when i = 1
+        assert_eq!(else_executed, false); // Outer else should NOT execute
     }
 
     #[test]
@@ -907,29 +566,26 @@ mod tests {
         let mut inner_sum = 0;
         let mut outer_else_executed = false;
         let mut inner_else_executed = false;
-        
-        pythonic_for!((i in 0..3) {
+        pythonic_for!(i in 0..3 { // Outer pythonic_for
             outer_sum += i;
-            
-            pythonic_for!((j in 0..3) {
+            pythonic_for!(j in 0..3 { // Inner pythonic_for
                 inner_sum += j;
-                
                 if j == 1 {
-                    break;
+                    break; // Breaks inner pythonic_for
                 }
             } else {
-                inner_else_executed = true;
+                inner_else_executed = true; // This should NOT execute
             });
-            
-        } else {
-            outer_else_executed = true;
+        } else { // Else for outer pythonic_for
+            outer_else_executed = true; // This SHOULD execute as outer loop completes
             outer_sum += 100;
         });
-        
-        assert_eq!(outer_sum, 103); // 0+1+2+100 = 103
-        assert_eq!(inner_sum, 3);   // (0+1)+(0+1)+(0+1) = 3
-        assert_eq!(inner_else_executed, true); // Inner else executes despite break
-        assert_eq!(outer_else_executed, true);
+        assert_eq!(outer_sum, 103); // 0+1+2+100
+        assert_eq!(inner_sum, 3);   // For i=0: (j=0, j=1, break) -> inner_sum=1. 
+                                    // For i=1: (j=0, j=1, break) -> inner_sum=1+1=2.
+                                    // For i=2: (j=0, j=1, break) -> inner_sum=2+1=3.
+        assert_eq!(inner_else_executed, false); // Inner `else` does not execute because of inner `break`.
+        assert_eq!(outer_else_executed, true); // Outer `else` executes.
     }
 
     #[test]
@@ -938,42 +594,309 @@ mod tests {
         let mut inner_sum = 0;
         let mut outer_else_executed = false;
         let mut inner_else_count = 0;
-        
-        pythonic_for!((i in 0..3) {
+        pythonic_for!(i in 0..3 { // Outer pythonic_for
             outer_sum += i;
-            
-            pythonic_for!((j in 0..3) {
+            pythonic_for!(j in 0..3 { // Inner pythonic_for
                 inner_sum += j;
-            } else {
-                inner_else_count += 1;
-                inner_sum += 10;
+            } else { // Else for inner pythonic_for
+                inner_else_count += 1; // This should execute for i=0 and i=1
+                inner_sum += 10; 
             });
-            
-            if i == 1 {
+            if i == 1 { // This break is for outer pythonic_for
                 break;
             }
-        } else {
-            outer_else_executed = true;
-            outer_sum += 100;
+        } else { // Else for outer pythonic_for
+            outer_else_executed = true; // This should NOT execute
         });
-        
-        assert_eq!(outer_sum, 101);   // 0+1+100 = 101 (outer else executes despite break)
-        assert_eq!(inner_sum, 26);  // (0+1+2)+(0+1+2)+10+10 = 26
-        assert_eq!(inner_else_count, 2);
-        assert_eq!(outer_else_executed, true);
+        assert_eq!(outer_sum, 1);   // i=0 (sum=0), i=1 (sum=0+1=1), then outer break.
+        // For i=0: inner loop (0+1+2=3), inner_else (sum=3+10=13). inner_sum_total = 13.
+        // For i=1: inner loop (0+1+2=3), inner_else (sum=3+10=13). inner_sum_total = 13+13=26.
+        assert_eq!(inner_sum, 26);  
+        assert_eq!(inner_else_count, 2); // Inner `else` runs for i=0 and i=1.
+        assert_eq!(outer_else_executed, false); // Outer `else` does not run due to outer `break`.
     }
+
+    // --- Tests for pythonic_while! ---
+
+    #[test]
+    fn test_while_basic_no_else() {
+        let mut count = 0;
+        let mut sum = 0;
+        pythonic_while!(count < 3; {
+            sum += count;
+            count += 1;
+        });
+        assert_eq!(sum, 3); // 0 + 1 + 2
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_while_basic_with_else_runs() {
+        let mut count = 0;
+        let mut sum = 0;
+        pythonic_while!(count < 3; {
+            sum += count;
+            count += 1;
+        } else {
+            sum += 100;
+        });
+        assert_eq!(sum, 103); // 0 + 1 + 2 + 100
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_while_basic_with_else_break() {
+        let mut count = 0;
+        let mut sum = 0;
+        pythonic_while!(count < 5; {
+            if count == 2 {
+                break;
+            }
+            sum += count;
+            count += 1;
+        } else {
+            sum += 100; // Should not run
+        });
+        assert_eq!(sum, 1); // 0 + 1
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_do_while_no_else() {
+        let mut count = 0;
+        let mut sum = 0;
+        // Simulates: do { sum += count; count += 1; } while count < 3; (extra body is empty)
+        pythonic_while!(do {
+            sum += count;
+            count += 1;
+        }; while count < 3; {}); // extra_body is empty
+        assert_eq!(sum, 3); // 0 (count=1) + 1 (count=2) + 2 (count=3) -> loop exits as count is not < 3
+        assert_eq!(count, 3);
+    }
+    
+    #[test]
+    fn test_do_while_no_else_with_extra_body() {
+        let mut count = 0;
+        let mut sum = 0;
+        pythonic_while!(do { // Body 1
+            sum += count;    // iter 1: sum=0, count=0 -> sum=0
+                             // iter 2: sum=1, count=1 -> sum=1+1=2
+        }; while count < 2; { // Condition checked: count=0<2 (true); count=1<2 (true); count=2<2 (false)
+            count += 1;      // Extra_body (Body 2)
+                             // iter 1: count=0 -> count=1
+                             // iter 2: count=1 -> count=2
+        });
+        // Iteration 1: body1 (sum=0, count=0), cond (0<2 true), extra_body (count=1)
+        // Iteration 2: body1 (sum=0+1=1, count=1), cond (1<2 true), extra_body (count=2)
+        // Iteration 3: body1 (sum=1+2=3, count=2), cond (2<2 false), loop terminates.
+        assert_eq!(sum, 3); 
+        assert_eq!(count, 2); // count becomes 2 in the last extra_body, then body1 runs once more.
+                               // Let's re-trace:
+                               // 1. count=0, sum=0
+                               // 2. body: sum=0 (0+0), count=0
+                               // 3. cond: 0 < 2 (true)
+                               // 4. extra_body: count=1
+                               // 5. body: sum=1 (0+1), count=1
+                               // 6. cond: 1 < 2 (true)
+                               // 7. extra_body: count=2
+                               // 8. body: sum=3 (1+2), count=2
+                               // 9. cond: 2 < 2 (false) -> terminate
+        assert_eq!(sum, 3);
+        assert_eq!(count, 2);
+    }
+
+
+    #[test]
+    fn test_do_while_with_else_runs() {
+        let mut count = 0;
+        let mut sum = 0;
+        pythonic_while!(do {
+            sum += count; // iter1: sum=0,c=0; iter2: sum=1,c=1; iter3: sum=3,c=2
+        }; while count < 2; { // cond1: 0<2 T; cond2: 1<2 T; cond3: 2<2 F
+            count += 1;   // iter1: c=1; iter2: c=2
+        } else {
+            sum += 100;
+        });
+        assert_eq!(sum, 103); // 3 + 100
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_do_while_with_else_break_in_first_body() {
+        let mut count = 0;
+        let mut sum = 0;
+        pythonic_while!(do {
+            if count == 1 {
+                break;
+            }
+            sum += count; // iter1: sum=0, c=0
+            count += 1;   // iter1: c=1
+        }; while count < 3; {
+            // extra_body, should not be reached if break occurs in first body before this
+        } else {
+            sum += 100; // Should not run
+        });
+        // Iteration 1: count=0. body: sum=0, count=1.
+        // Iteration 2: count=1. body: break.
+        assert_eq!(sum, 0); 
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_do_while_with_else_break_in_extra_body() {
+        let mut count = 0;
+        let mut sum = 0;
+        pythonic_while!(do {
+            sum += count;    // iter1: sum=0, c=0; iter2: sum=1, c=1
+        }; while count < 3; { // cond1: 0<3 T; cond2: 1<3 T
+            count += 1;      // iter1: c=1; iter2: c=2
+            if count == 2 {
+                break;       // Breaks here on second iteration of extra_body
+            }
+        } else {
+            sum += 100; // Should not run
+        });
+        // Iteration 1: body (sum=0, c=0), cond (0<3 T), extra_body (c=1)
+        // Iteration 2: body (sum=0+1=1, c=1), cond (1<3 T), extra_body (c=2, break)
+        assert_eq!(sum, 1); 
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_while_false_condition_else_runs() {
+        let mut body_executed = false;
+        let mut else_executed = false;
+        pythonic_while!(false; {
+            body_executed = true;
+        } else {
+            else_executed = true;
+        });
+        assert!(!body_executed);
+        assert!(else_executed);
+    }
+    
+    #[test]
+    fn test_do_while_false_condition_else_runs() {
+        // For do-while, the first body always runs once.
+        // Then condition is checked. If false, loop terminates, else runs.
+        let mut body_executed_count = 0;
+        let mut extra_body_executed = false;
+        let mut else_executed = false;
+
+        pythonic_while!(do {
+            body_executed_count += 1; // Runs once
+        }; while false; { // Condition is immediately false
+            extra_body_executed = true; // Should not run
+        } else {
+            else_executed = true; // Should run
+        });
+        assert_eq!(body_executed_count, 1);
+        assert!(!extra_body_executed);
+        assert!(else_executed);
+    }
+
+
+    #[test]
+    fn test_while_panic_handling_no_else() {
+        let result = std::panic::catch_unwind(|| {
+            let mut count = 0;
+            pythonic_while!(count < 3; {
+                if count == 1 {
+                    panic!("Test panic in while no else");
+                }
+                count += 1;
+            });
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_while_panic_handling_with_else() {
+        let mut else_ran = false;
+        let result = std::panic::catch_unwind(|| {
+            let mut count = 0;
+            pythonic_while!(count < 3; {
+                if count == 1 {
+                    panic!("Test panic in while with else");
+                }
+                count += 1;
+            } else {
+                else_ran = true;
+            });
+        });
+        assert!(result.is_err());
+        assert!(!else_ran, "Else clause should not run if panic occurred in body");
+    }
+    
+    #[test]
+    fn test_do_while_panic_in_first_body_no_else() {
+        let result = std::panic::catch_unwind(|| {
+            let mut count = 0;
+            pythonic_while!(do {
+                if count == 0 { // Panic on first execution of body
+                    panic!("Test panic in do-while first body no else");
+                }
+                count += 1;
+            }; while count < 2; {});
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_do_while_panic_in_first_body_with_else() {
+        let mut else_ran = false;
+        let result = std::panic::catch_unwind(|| {
+            let mut count = 0;
+            pythonic_while!(do {
+                if count == 0 {
+                     panic!("Test panic in do-while first body with else");
+                }
+                count += 1;
+            }; while count < 2; {}
+            else {
+                else_ran = true;
+            });
+        });
+        assert!(result.is_err());
+        assert!(!else_ran);
+    }
+    
+    #[test]
+    fn test_do_while_panic_in_extra_body_no_else() {
+        let result = std::panic::catch_unwind(|| {
+            let mut count = 0;
+            pythonic_while!(do {
+                // This part runs fine
+                count = 5; 
+            }; while count < 10; { // Condition is true
+                panic!("Test panic in do-while extra_body no else");
+            });
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_do_while_panic_in_extra_body_with_else() {
+        let mut else_ran = false;
+        let result = std::panic::catch_unwind(|| {
+            let mut count = 0;
+             pythonic_while!(do {
+                count = 5;
+            }; while count < 10; { // Condition is true
+                panic!("Test panic in do-while extra_body with else");
+            } else {
+                else_ran = true;
+            });
+        });
+        assert!(result.is_err());
+        assert!(!else_ran);
+    }
+
 }
 
-#[macro_export]
-#[doc(hidden)]
-macro_rules! _internal_pythonic_for_body {
-    ($body:block) => {
-        pythonic_for_proc_macros::transform_body! { $body }
-    };
-}
 #[doc(hidden)]
 #[inline]
-pub fn _is_likely_cycle<I>(_iter: &I) -> bool {
+pub fn is_cycle_iterator<I>(_iter: &I) -> bool { // Renamed from _is_likely_cycle
     let type_name = std::any::type_name::<I>();
     type_name.contains("std::iter::Cycle") || type_name.contains("::Cycle<")
 }
@@ -983,27 +906,26 @@ pub fn _is_likely_cycle<I>(_iter: &I) -> bool {
     note = "Warning: Using cycle() iterator with else clause may create a logical error. \
            The else clause will never execute because cycle() creates an infinite iterator. \
            Consider adding a break condition in your loop body if this is intentional."
-)]
+)] // Note does not mention the helper function name, so it's fine.
 #[doc(hidden)]
 #[inline]
 pub fn _warn_cycle_with_else() {
 }
 
-/// 
 /// immediately skip to the else clause without any iteration.
 #[doc(hidden)]
 #[inline]
-pub fn _is_likely_false_condition(condition: &str) -> bool {
+pub fn is_false_condition(condition: &str) -> bool { // Renamed from _is_likely_false_condition
     condition == "false" || 
     condition == "0 == 1" || 
     condition == "1 == 0" ||
     condition == "0 != 0" ||
     condition == "1 != 1" ||
-    condition.contains(" < ") && condition.split(" < ").collect::<Vec<&str>>().len() == 2 &&
-        condition.split(" < ").nth(0).unwrap().trim().parse::<i32>().is_ok() &&
-        condition.split(" < ").nth(1).unwrap().trim().parse::<i32>().is_ok() &&
-        condition.split(" < ").nth(0).unwrap().trim().parse::<i32>().unwrap() >= 
-        condition.split(" < ").nth(1).unwrap().trim().parse::<i32>().unwrap()
+    (condition.contains(" < ") && condition.split(" < ").collect::<Vec<&str>>().len() == 2 &&
+        condition.split(" < ").next().unwrap_or_default().trim().parse::<i32>().is_ok() &&
+        condition.split(" < ").nth(1).unwrap_or_default().trim().parse::<i32>().is_ok() &&
+        condition.split(" < ").next().unwrap_or_default().trim().parse::<i32>().unwrap_or(1) >= 
+        condition.split(" < ").nth(1).unwrap_or_default().trim().parse::<i32>().unwrap_or(0))
 }
 
 #[deprecated(
@@ -1025,7 +947,7 @@ pub fn _warn_false_condition_with_else() {
 /// # Examples
 ///
 /// ```
-/// use pythonic_for::pythonic_while;
+/// use pythonic_for::pythonic_while; 
 ///
 /// // Basic while-else loop - no break occurs, so else clause executes
 /// let mut counter = 0;
@@ -1038,23 +960,22 @@ pub fn _warn_false_condition_with_else() {
 ///     result += 100;
 /// });
 ///
-/// assert_eq!(result, 110); // 0+1+2+3+4+100 = 110
+/// assert_eq!(result, 110); 
 /// ```
 ///
 /// ```
-/// use pythonic_for::pythonic_while;
+/// use pythonic_for::pythonic_while; 
 ///
 /// let mut counter = 0;
 /// let mut result = 0;
 ///
-/// // We'll use a separate test without an else clause
 /// pythonic_while!(counter < 1; {
 ///     result += counter;
 ///     counter += 1;
 /// });
 ///
-/// assert_eq!(result, 0); // Counter starts at 0, so result = 0
-/// assert_eq!(counter, 1); // Counter is incremented to 1
+/// assert_eq!(result, 0); 
+/// assert_eq!(counter, 1); 
 /// ```
 #[macro_export]
 macro_rules! pythonic_while {
@@ -1062,21 +983,15 @@ macro_rules! pythonic_while {
     ($condition:expr; $body:block) => {
         {
             let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let __result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 'pythonic_while_loop: while $condition {
-                    $crate::_internal_pythonic_while_body!($body);
-                    
-                    if _break_occurred {
+                    $crate::_internal_pythonic_while_body!('pythonic_while_loop, { $body }); 
+                    if _break_occurred { 
                         break 'pythonic_while_loop;
                     }
                 }
             }));
-
-            if result.is_err() {
-                _error_occurred = true;
-            }
+            // If __result.is_err(), panic is caught.
         }
     };
 
@@ -1084,31 +999,23 @@ macro_rules! pythonic_while {
     ($condition:expr; $body:block else $else_body:block) => {
         {
             let condition_str = stringify!($condition);
-            let _false_condition_detected = $crate::_is_likely_false_condition(condition_str);
+            let _false_condition_detected = $crate::is_false_condition(condition_str); // Updated call site
             
             if _false_condition_detected {
                 $crate::_warn_false_condition_with_else();
             }
             
             let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let __result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 'pythonic_while_loop: while $condition {
-                    $crate::_internal_pythonic_while_body!($body);
-                    
+                    $crate::_internal_pythonic_while_body!('pythonic_while_loop, { $body });
                     if _break_occurred {
                         break 'pythonic_while_loop;
                     }
                 }
             }));
 
-            if result.is_err() {
-                _error_occurred = true;
-            }
-
-            // Execute the else body only if no break occurred and no error occurred
-            if !_break_occurred && !_error_occurred {
+            if !_break_occurred && __result.is_ok() {
                 $else_body
             }
         }
@@ -1118,31 +1025,22 @@ macro_rules! pythonic_while {
     (do $body:block; while $condition:expr; $extra_body:block) => {
         {
             let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let __result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 'pythonic_while_loop: loop {
-                    $crate::_internal_pythonic_while_body!($body);
-                    
+                    $crate::_internal_pythonic_while_body!('pythonic_while_loop, { $body });
                     if _break_occurred {
                         break 'pythonic_while_loop;
                     }
-                    
                     if !($condition) {
-                        break 'pythonic_while_loop;
+                        break 'pythonic_while_loop; 
                     }
-                    
-                    $crate::_internal_pythonic_while_body!($extra_body);
-                    
+                    $crate::_internal_pythonic_while_body!('pythonic_while_loop, { $extra_body }); 
                     if _break_occurred {
                         break 'pythonic_while_loop;
                     }
                 }
             }));
-
-            if result.is_err() {
-                _error_occurred = true;
-            }
+            // If __result.is_err(), panic is caught.
         }
     };
 
@@ -1150,41 +1048,30 @@ macro_rules! pythonic_while {
     (do $body:block; while $condition:expr; $extra_body:block else $else_body:block) => {
         {
             let condition_str = stringify!($condition);
-            let _false_condition_detected = $crate::_is_likely_false_condition(condition_str);
+            let _false_condition_detected = $crate::is_false_condition(condition_str); // Updated call site
             
             if _false_condition_detected {
                 $crate::_warn_false_condition_with_else();
             }
             
             let mut _break_occurred = false;
-            let mut _error_occurred = false;
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let __result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 'pythonic_while_loop: loop {
-                    $crate::_internal_pythonic_while_body!($body);
-                    
+                    $crate::_internal_pythonic_while_body!('pythonic_while_loop, { $body });
                     if _break_occurred {
                         break 'pythonic_while_loop;
                     }
-                    
                     if !($condition) {
                         break 'pythonic_while_loop;
                     }
-                    
-                    $crate::_internal_pythonic_while_body!($extra_body);
-                    
+                    $crate::_internal_pythonic_while_body!('pythonic_while_loop, { $extra_body });
                     if _break_occurred {
                         break 'pythonic_while_loop;
                     }
                 }
             }));
 
-            if result.is_err() {
-                _error_occurred = true;
-            }
-
-            // Execute the else body only if no break occurred and no error occurred
-            if !_break_occurred && !_error_occurred {
+            if !_break_occurred && __result.is_ok() {
                 $else_body
             }
         }
@@ -1194,7 +1081,8 @@ macro_rules! pythonic_while {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! _internal_pythonic_while_body {
-    ($body:block) => {
-        pythonic_for_proc_macros::transform_body! { $body }
+    ($label:lifetime, $body:block) => {
+        // Pass the label and the body to the transform_body proc macro
+        pythonic_for_proc_macros::transform_body!($label, { $body })
     };
 }


### PR DESCRIPTION
- Bumped version of `pythonic-for` to `0.2.0` due to breaking API changes (macro syntax) and significant new features (`pythonic_while!`).
- Bumped version of `pythonic-for-proc-macros` to `0.2.0` to align and reflect internal API changes.
- Updated crate descriptions to include `while` loop functionality.
- Expanded keywords for better discoverability.
- Removed "no-std" category as `std::panic::catch_unwind` is used.